### PR TITLE
NodeJS option

### DIFF
--- a/lambda-pure.zsh
+++ b/lambda-pure.zsh
@@ -151,7 +151,10 @@ prompt_pure_preprompt_render() {
 	preprompt+="%F{cyan}${prompt_pure_cmd_exec_time}%f"
 
 	# NodeJS version
-	local rpreprompt="%F{green}⬢ ${prompt_pure_node_version}%f"
+	local rpreprompt
+	if (( ${PURE_NODE_ENABLED:-1} )); then
+	    rpreprompt+="%F{green}⬢ ${prompt_pure_node_version}%f"
+	fi
 
 	integer preprompt_left_length preprompt_right_length space_length
 	prompt_pure_string_length_to_var "${preprompt}" "preprompt_left_length"

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ That's it. Skip to [Getting started](#getting-started).
   - add it as a submodule, or
   - just download `lambda-pure.zsh` and `async.zsh`
 
-2. Symlink `lambda-pure.zsh` to somewhere in [`$fpath`](http://www.refining-linux.org/archives/46/ZSH-Gem-12-Autoloading-functions/) with the name `prompt_lambda-pure_setup`.
+2. Symlink `lambda-pure.zsh` to somewhere in [`$fpath`](https://www.refining-linux.org/archives/46-ZSH-Gem-12-Autoloading-functions.html) with the name `prompt_lambda-pure_setup`.
 
 3. Symlink `async.zsh` in `$fpath` with the name `async`.
 

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,10 @@ Defines the git up arrow symbol. The default value is `▲`.
 
 Defines the git dirty symbol. The default value is `×`.
 
+### `PURE_NODE_ENABLED`
+
+Set `PURE_NODE_ENABLED=0` to not display the NodeJS version.
+
 ## Example
 
 ```sh


### PR DESCRIPTION
I love this theme but I don't want to show the NodeJS version, so I decided to add an option to disable it. Is there a better place in the code base to disable the Node version being outputted? Let me know what you think @marszall87.