### PR TITLE
Guards against missing output from worker

### DIFF
--- a/lambda-pure.zsh
+++ b/lambda-pure.zsh
@@ -327,8 +327,13 @@ prompt_pure_async_tasks() {
 
 prompt_pure_async_callback() {
 	local job=$1
-	local output=$3
-	local exec_time=$4
+        if [[ $# == 5 ]]; then
+            local output=$3
+            local exec_time=$4
+        else
+            local output=
+            local exec_tim=$3
+        fi
 
 	case "${job}" in
 		prompt_pure_async_git_dirty)


### PR DESCRIPTION
There is a bug with pulling git information such that one of the workers sends the incorrect number of arguments to it's callback.
This fix prevents the prompt from crashing.
Ultimately the underlying issue with the worker should be corrected.