### PR TITLE
fixed error in prompt_pure_async_callback

### DIFF
--- a/lambda-pure.zsh
+++ b/lambda-pure.zsh
@@ -343,7 +343,7 @@ prompt_pure_async_callback() {
 			# When prompt_pure_git_last_dirty_check_timestamp is set, the git info is displayed in a different color.
 			# To distinguish between a "fresh" and a "cached" result, the preprompt is rendered before setting this
 			# variable. Thus, only upon next rendering of the preprompt will the result appear in a different color.
-			(( $exec_time > 2 )) && prompt_pure_git_last_dirty_check_timestamp=$EPOCHSECONDS
+			[[ $exec_time -gt 2 ]] && prompt_pure_git_last_dirty_check_timestamp=$EPOCHSECONDS
 			;;
 		prompt_pure_async_git_fetch)
 			prompt_pure_check_git_arrows


### PR DESCRIPTION
Full error message: prompt_pure_async_callback:13: bad math expression: operand expected at `> 2 '.
Since the conditional was comparing a variable and a integer, we must use the square brackets and gt syntax.
