### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,14 @@ $ npm install --global lambda-pure-prompt
 
 That's it. Skip to [Getting started](#getting-started).
 
+### Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `lambda-pure` in just one click.
+
+<a href="https://fig.io/plugins/other/lambda-pure_marszall87" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Manually
 
 1. Either…


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Lambda Pure is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!